### PR TITLE
Implement deliver_async in the adapter

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -13,9 +13,7 @@ defmodule Bamboo.Mailer do
       end
 
       def deliver_async(email) do
-        Task.async(fn ->
-          deliver(email)
-        end)
+        Bamboo.Mailer.deliver_async(@adapter, email, @config)
       end
     end
   end
@@ -24,6 +22,12 @@ defmodule Bamboo.Mailer do
     email = email |> Bamboo.Mailer.normalize_addresses
 
     adapter.deliver(email, config)
+  end
+
+  def deliver_async(adapter, email, config) do
+    email = email |> Bamboo.Mailer.normalize_addresses
+
+    adapter.deliver_async(email, config)
   end
 
   def normalize_addresses(email) do

--- a/lib/bamboo/mandrill_adapter.ex
+++ b/lib/bamboo/mandrill_adapter.ex
@@ -8,6 +8,12 @@ defmodule Bamboo.MandrillAdapter do
     request(@send_message_path, params)
   end
 
+  def deliver_async(email, config) do
+    Task.async(fn ->
+      deliver(email, config)
+    end)
+  end
+
   defp convert_to_mandrill_params(email, api_key) do
     %{api_key: api_key, message: message_params(email)}
   end

--- a/lib/bamboo/test_adapter.ex
+++ b/lib/bamboo/test_adapter.ex
@@ -4,4 +4,9 @@ defmodule Bamboo.TestAdapter do
   def deliver(email, _config) do
     TestMailbox.push(email)
   end
+
+  def deliver_async(email, _config) do
+    deliver(email, nil)
+    Task.async(fn -> end)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Bamboo.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [:logger, :cowboy, :httpoison, :poison],
+      applications: [:logger, :httpoison, :poison],
       mod: {Bamboo, []}
     ]
   end

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -7,6 +7,10 @@ defmodule Bamboo.MailerTest do
     def deliver(email, config) do
       send :test, {:deliver, email, config}
     end
+
+    def deliver_async(email, config) do
+      send :test, {:deliver_async, email, config}
+    end
   end
 
   @mailer_config adapter: FooAdapter, foo: :bar
@@ -37,22 +41,13 @@ defmodule Bamboo.MailerTest do
     assert delivered_email.from == %{name: nil, address: nil}
   end
 
-  test "deliver_async/1 calls the regular deliver method asynchronously" do
+  test "deliver_async/1 calls deliver_async on the adapter" do
     email = new_email
 
     FooMailer.deliver_async(email)
 
-    assert_receive {:deliver, delivered_email, _}
-    assert delivered_email == Bamboo.Mailer.normalize_addresses(email)
-  end
-
-  test "deliver_async/1 returns a Task that can be awaited on" do
-    email = new_email
-
-    task = FooMailer.deliver_async(email)
-
-    Task.await(task)
-    assert_received {:deliver, delivered_email, _}
+    assert_receive {:deliver_async, delivered_email, config}
+    assert config == @mailer_config
     assert delivered_email == Bamboo.Mailer.normalize_addresses(email)
   end
 

--- a/test/lib/bamboo/mandrill_adapter_test.exs
+++ b/test/lib/bamboo/mandrill_adapter_test.exs
@@ -77,6 +77,29 @@ defmodule Bamboo.MandrillAdapterTest do
     assert message["headers"] == email.headers
   end
 
+  test "deliver_async sends asynchronously and can be awaited upon" do
+    email = new_email(
+      from: %{name: "From", address: "from@foo.com"},
+      subject: "My Subject",
+      text_body: "TEXT BODY",
+      html_body: "HTML BODY",
+    )
+    |> Email.put_header("Reply-To", "reply@foo.com")
+
+    task = email |> Mailer.deliver_async
+
+    Task.await(task)
+    assert_receive {:fake_mandrill, %{params: params}}
+    assert params["api_key"] == @api_key
+    message = params["message"]
+    assert message["from_email"] == email.from.address
+    assert message["from_name"] == email.from.name
+    assert message["subject"] == email.subject
+    assert message["text"] == email.text_body
+    assert message["html"] == email.html_body
+    assert message["headers"] == email.headers
+  end
+
   test "deliver/2 correctly formats recipients" do
     email = new_email(
       to: [%{name: "To", address: "to@bar.com"}],

--- a/test/lib/bamboo/test_adapter_test.exs
+++ b/test/lib/bamboo/test_adapter_test.exs
@@ -16,11 +16,28 @@ defmodule Bamboo.TestAdapterTest do
     TestMailbox.reset
   end
 
-  test "deliveries contains emails that have been delivered" do
+  test "deliveries has emails that have been delivered synchronously" do
     email = new_normalized_email(subject: "This is my email")
 
     email |> TestMailer.deliver
 
+    assert TestMailbox.deliveries == [email]
+  end
+
+  test "deliver_async puts email in the mailbox immediately" do
+    email = new_normalized_email(subject: "This is my email")
+
+    email |> TestMailer.deliver_async
+
+    assert TestMailbox.deliveries == [email]
+  end
+
+  test "deliver_async returns a task that can be awaited upon" do
+    email = new_normalized_email(subject: "This is my email")
+
+    task = email |> TestMailer.deliver_async
+
+    Task.await(task)
     assert TestMailbox.deliveries == [email]
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
 ExUnit.start()
 Application.ensure_all_started(:phoenix)
+Application.ensure_all_started(:cowboy)


### PR DESCRIPTION
This allows the TestAdapter to store emails immediately so that
deliveries are available right away when testing. There may be a better
way to do this, but this works well for now.