### PR TITLE
Rename deliver_async to deliver_later

### DIFF
--- a/lib/bamboo/adapter_behaviour.ex
+++ b/lib/bamboo/adapter_behaviour.ex
@@ -13,7 +13,7 @@ defmodule Bamboo.Adapter do
           deliver_the_email_somehow(email)
         end
 
-        def deliver_async(email, config) do
+        def deliver_later(email, config) do
           # You could also add the email to a GenServer or ExQ for delivery.
           Task.async fn ->
             Bamboo.CustomAdapter.deliver(email, config)
@@ -23,5 +23,5 @@ defmodule Bamboo.Adapter do
   """
 
   @callback deliver(%Bamboo.Email{}, %{}) :: any
-  @callback deliver_async(%Bamboo.Email{}, %{}) :: Task.t
+  @callback deliver_later(%Bamboo.Email{}, %{}) :: Task.t
 end

--- a/lib/bamboo/adapters/local_adapter.ex
+++ b/lib/bamboo/adapters/local_adapter.ex
@@ -29,7 +29,7 @@ defmodule Bamboo.LocalAdapter do
   end
 
   @doc "Adds email to Bamboo.SentEmail. Returns a Task that can be awaited on"
-  def deliver_async(email, _config) do
+  def deliver_later(email, _config) do
     deliver(email, nil)
     Task.async(fn -> :ok end)
   end

--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -53,7 +53,7 @@ defmodule Bamboo.MandrillAdapter do
     end
   end
 
-  def deliver_async(email, config) do
+  def deliver_later(email, config) do
     Task.async(fn ->
       deliver(email, config)
     end)

--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -25,7 +25,7 @@ defmodule Bamboo.TestAdapter do
   end
 
   @doc false
-  def deliver_async(email, _config) do
+  def deliver_later(email, _config) do
     deliver(email, nil)
     Task.async(fn -> :ok end)
   end

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -2,7 +2,7 @@ defmodule Bamboo.Mailer do
   @moduledoc """
   Sets up mailers that make it easy to configure and swap adapters.
 
-  Adds deliver/1 and deliver_async/1 functions to the mailer module it is used by.
+  Adds deliver/1 and deliver_later/1 functions to the mailer module it is used by.
   Bamboo ships with [Bamboo.MandrillAdapter](Bamboo.MandrillAdapter.html),
   [Bamboo.LocalAdapter](Bamboo.LocalAdapter) and
   [Bamboo.TestAdapter](Bamboo.TestAdapter.html).
@@ -18,7 +18,7 @@ defmodule Bamboo.Mailer do
 
       # Somewhere in your application. Maybe lib/my_app/mailer.ex
       defmodule MyApp.Mailer do
-        # Adds deliver/1 and deliver_async/1
+        # Adds deliver/1 and deliver_later/1
         use Bamboo.Mailer, otp_app: :my_app
       end
 
@@ -44,7 +44,7 @@ defmodule Bamboo.Mailer do
 
         def register_user do
           # Create a user and whatever else is needed
-          # Could also have called Mailer.deliver_async
+          # Could also have called Mailer.deliver_later
           Email.welcome_email |> Mailer.deliver
         end
       end
@@ -64,8 +64,8 @@ defmodule Bamboo.Mailer do
         Bamboo.Mailer.deliver(@adapter, email, @config)
       end
 
-      def deliver_async(email) do
-        Bamboo.Mailer.deliver_async(@adapter, email, @config)
+      def deliver_later(email) do
+        Bamboo.Mailer.deliver_later(@adapter, email, @config)
       end
     end
   end
@@ -79,11 +79,11 @@ defmodule Bamboo.Mailer do
   end
 
   @doc false
-  def deliver_async(adapter, email, config) do
+  def deliver_later(adapter, email, config) do
     email = email |> Bamboo.Mailer.normalize_addresses
 
     debug(email)
-    adapter.deliver_async(email, config)
+    adapter.deliver_later(email, config)
   end
 
   defp debug(email) do

--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -34,7 +34,7 @@ defmodule Bamboo.Test do
 
           email |> MyApp.Mailer.deliver
 
-          # Also works with MyApp.Mailer.deliver_async
+          # Also works with MyApp.Mailer.deliver_later
           assert_delivered_email Emails.welcome_email(user)
         end
       end

--- a/test/lib/bamboo/local_adapter_test.exs
+++ b/test/lib/bamboo/local_adapter_test.exs
@@ -24,18 +24,18 @@ defmodule Bamboo.LocalAdapterTest do
     assert SentEmail.all == [email]
   end
 
-  test "deliver_async puts email in the mailbox immediately" do
+  test "deliver_later puts email in the mailbox immediately" do
     email = new_normalized_email(subject: "This is my email")
 
-    email |> TestMailer.deliver_async
+    email |> TestMailer.deliver_later
 
     assert SentEmail.all == [email]
   end
 
-  test "deliver_async returns a task that can be awaited upon" do
+  test "deliver_later returns a task that can be awaited upon" do
     email = new_normalized_email(subject: "This is my email")
 
-    task = email |> TestMailer.deliver_async
+    task = email |> TestMailer.deliver_later
 
     Task.await(task)
     assert SentEmail.all == [email]

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -9,8 +9,8 @@ defmodule Bamboo.MailerTest do
       send :test, {:deliver, email, config}
     end
 
-    def deliver_async(email, config) do
-      send :test, {:deliver_async, email, config}
+    def deliver_later(email, config) do
+      send :test, {:deliver_later, email, config}
     end
   end
 
@@ -41,12 +41,12 @@ defmodule Bamboo.MailerTest do
     end
   end
 
-  test "deliver_async/1 calls deliver_async on the adapter" do
+  test "deliver_later/1 calls deliver_later on the adapter" do
     email = new_email
 
-    FooMailer.deliver_async(email)
+    FooMailer.deliver_later(email)
 
-    assert_receive {:deliver_async, delivered_email, config}
+    assert_receive {:deliver_later, delivered_email, config}
     assert config == @mailer_config
     assert delivered_email == Bamboo.Mailer.normalize_addresses(email)
   end

--- a/test/lib/bamboo/mandrill_adapter_test.exs
+++ b/test/lib/bamboo/mandrill_adapter_test.exs
@@ -92,7 +92,7 @@ defmodule Bamboo.MandrillAdapterTest do
     assert message["headers"] == email.headers
   end
 
-  test "deliver_async sends asynchronously and can be awaited upon" do
+  test "deliver_later sends asynchronously and can be awaited upon" do
     email = new_email(
       from: %EmailAddress{name: "From", address: "from@foo.com"},
       subject: "My Subject",
@@ -101,7 +101,7 @@ defmodule Bamboo.MandrillAdapterTest do
     )
     |> Email.put_header("Reply-To", "reply@foo.com")
 
-    task = email |> Mailer.deliver_async
+    task = email |> Mailer.deliver_later
 
     Task.await(task)
     assert_receive {:fake_mandrill, %{params: params}}

--- a/test/lib/bamboo/test_adapter_test.exs
+++ b/test/lib/bamboo/test_adapter_test.exs
@@ -20,10 +20,10 @@ defmodule Bamboo.TestAdapterTest do
     assert_received {:delivered_email, ^email}
   end
 
-  test "deliver_async/2 sends a message to the process and returns a Task" do
+  test "deliver_later/2 sends a message to the process and returns a Task" do
     email = new_normalized_email()
 
-    task = email |> TestMailer.deliver_async
+    task = email |> TestMailer.deliver_later
 
     Task.await(task)
     assert_received {:delivered_email, ^email}


### PR DESCRIPTION
deliver_async is misleading because this function is not meant to be
awaited on. Instead it's meant as more of a "send it and forget it"
function. It can always be customized with a custom adapter if you want
to do something different. I think deliver_later is more flexible and
doesn't have as many misleading connotations.

Closes #54 