### PR TITLE
Filter API key when raising API errors

### DIFF
--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -27,6 +27,8 @@ defmodule Bamboo.MandrillAdapter do
     defexception [:message]
 
     def exception(%{params: params, response: response}) do
+      filtered_params = params |> Poison.decode! |> Map.put("key", "[FILTERED]")
+
       message = """
       There was a problem sending the email through the Mandrill API.
 
@@ -37,7 +39,7 @@ defmodule Bamboo.MandrillAdapter do
 
       Here are the params we sent:
 
-      #{inspect Poison.decode!(params), limit: :infinity}
+      #{inspect filtered_params, limit: :infinity}
       """
       %ApiError{message: message}
     end

--- a/test/lib/bamboo/mandrill_adapter_test.exs
+++ b/test/lib/bamboo/mandrill_adapter_test.exs
@@ -138,6 +138,14 @@ defmodule Bamboo.MandrillAdapterTest do
     end
   end
 
+  test "removes api key from error output" do
+    email = new_email(from: "INVALID_EMAIL")
+
+    assert_raise Bamboo.MandrillAdapter.ApiError, ~r/"key" => "\[FILTERED\]"/, fn ->
+      email |> MandrillAdapter.deliver(@config)
+    end
+  end
+
   defp new_email(attrs \\ []) do
     attrs = Keyword.merge([from: "foo@bar.com", to: []], attrs)
     Email.new_email(attrs) |> Bamboo.Mailer.normalize_addresses


### PR DESCRIPTION
That way API keys aren't accidentally stored in the logs. Closes #66