### PR TITLE
Deliver later strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,21 @@ To use the latest from master.
         def application do
           [applications: [:bamboo]]
         end
+
+  3. Add the the Bamboo.TaskSupervior as a child to your supervisor
+
+  ```elixir
+  # Usually in lib/my_app_name/my_app_name.ex
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    children = [
+      # Add the supervisor that handles deliver_later calls
+      Bamboo.TaskSupervisorStrategy.child_spec
+    ]
+
+    # This part is usually already there.
+    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+  ```

--- a/lib/bamboo.ex
+++ b/lib/bamboo.ex
@@ -29,5 +29,13 @@ defmodule Bamboo do
     end
   end
 
-  def start(_type, _args), do: Bamboo.SentEmail.start_link
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    children = [
+      worker(Bamboo.SentEmail, []),
+    ]
+    opts = [strategy: :one_for_one, name: Bamboo.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
 end

--- a/lib/bamboo/adapter_behaviour.ex
+++ b/lib/bamboo/adapter_behaviour.ex
@@ -1,8 +1,6 @@
 defmodule Bamboo.Adapter do
-  @moduledoc """
+  @moduledoc ~S"""
   Use this behaviour when creating adapters to be used by Bamboo.
-
-  Accepts an email, and the config that was set for the mailer.
 
   ## Example
 
@@ -13,15 +11,20 @@ defmodule Bamboo.Adapter do
           deliver_the_email_somehow(email)
         end
 
-        def deliver_later(email, config) do
-          # You could also add the email to a GenServer or ExQ for delivery.
-          Task.async fn ->
-            Bamboo.CustomAdapter.deliver(email, config)
+        def handle_config(config) do
+          # Return the config if nothing special is required
+          config
+
+          # Or you could require certain config options
+          if Map.get(config, :smtp_username) do
+            config
+          else
+            raise "smpt_username is required in config, got #{inspect config}"
           end
         end
       end
   """
 
   @callback deliver(%Bamboo.Email{}, %{}) :: any
-  @callback deliver_later(%Bamboo.Email{}, %{}) :: Task.t
+  @callback handle_config(map) :: map
 end

--- a/lib/bamboo/adapters/local_adapter.ex
+++ b/lib/bamboo/adapters/local_adapter.ex
@@ -28,9 +28,22 @@ defmodule Bamboo.LocalAdapter do
     SentEmail.push(email)
   end
 
-  @doc "Adds email to Bamboo.SentEmail. Returns a Task that can be awaited on"
-  def deliver_later(email, _config) do
-    deliver(email, nil)
-    Task.async(fn -> :ok end)
+  def handle_config(config) do
+    case config[:deliver_later_strategy] do
+      nil ->
+        Map.put(config, :deliver_later_strategy, Bamboo.DeliverImmediatelyStrategy)
+      Bamboo.DeliverImmediatelyStrategy ->
+        config
+      _ ->
+        raise ArgumentError, """
+        Bamboo.LocalAdapter requires that the deliver_later_strategy is
+        Bamboo.DeliverImmediatelyStrategy
+
+        Instead it got: #{inspect config[:deliver_later_strategy]}
+
+        Please remove the deliver_later_strategy from your config options, or
+        set it to Bamboo.DeliverImmediatelyStrategy.
+        """
+    end
   end
 end

--- a/lib/bamboo/adapters/mandrill_adapter.ex
+++ b/lib/bamboo/adapters/mandrill_adapter.ex
@@ -4,7 +4,7 @@ defmodule Bamboo.MandrillAdapter do
 
   Use this adapter to send emails through Mandrill's API. Requires that an API
   key is set in the config. See [Bamboo.MandrillEmail](Bamboo.MandrillEmail.html)
-  extra functions that can be used by the MandrillAdapter (tagging, merge vars, etc.)
+  for extra functions that can be used by the MandrillAdapter (tagging, merge vars, etc.)
 
   ## Example config
 
@@ -55,14 +55,17 @@ defmodule Bamboo.MandrillAdapter do
     end
   end
 
-  def deliver_later(email, config) do
-    Task.async(fn ->
-      deliver(email, config)
-    end)
+  @doc false
+  def handle_config(config) do
+    if config[:api_key] in [nil, ""] do
+      raise_api_key_error(config)
+    else
+      config
+    end
   end
 
   defp get_key(config) do
-    case Keyword.get(config, :api_key) do
+    case Map.get(config, :api_key) do
       nil -> raise_api_key_error(config)
       key -> key
     end

--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -24,9 +24,22 @@ defmodule Bamboo.TestAdapter do
     send self(), {:delivered_email, email}
   end
 
-  @doc false
-  def deliver_later(email, _config) do
-    deliver(email, nil)
-    Task.async(fn -> :ok end)
+  def handle_config(config) do
+    case config[:deliver_later_strategy] do
+      nil ->
+        Map.put(config, :deliver_later_strategy, Bamboo.DeliverImmediatelyStrategy)
+      Bamboo.DeliverImmediatelyStrategy ->
+        config
+      _ ->
+        raise ArgumentError, """
+        Bamboo.TestAdapter requires that the deliver_later_strategy is
+        Bamboo.DeliverImmediatelyStrategy
+
+        Instead it got: #{inspect config[:deliver_later_strategy]}
+
+        Please remove the deliver_later_strategy from your config options, or
+        set it to Bamboo.DeliverImmediatelyStrategy.
+        """
+    end
   end
 end

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -87,7 +87,7 @@ defmodule Bamboo.Mailer do
   def deliver_later(adapter, email, config) do
     email = email |> validate_and_normalize
 
-    adapter.deliver_later(email, config)
+    config.deliver_later_strategy.deliver_later(adapter, email, config)
   end
 
   defp debug_sent(email, adapter) do
@@ -139,6 +139,9 @@ defmodule Bamboo.Mailer do
   @doc false
   def parse_opts(mailer, opts) do
     otp_app = Keyword.fetch!(opts, :otp_app)
-    Application.get_env(otp_app, mailer) |> Enum.into(%{})
+    config = Application.get_env(otp_app, mailer) |> Enum.into(%{})
+
+    config.adapter.handle_config(config)
+    |> Map.put_new(:deliver_later_strategy, Bamboo.TaskSupervisorStrategy)
   end
 end

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -55,9 +55,9 @@ defmodule Bamboo.Mailer do
 
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do
-      %{adapter: adapter, config: config} = Bamboo.Mailer.parse_opts(__MODULE__, opts)
+      config = Bamboo.Mailer.parse_opts(__MODULE__, opts)
 
-      @adapter adapter
+      @adapter config.adapter
       @config config
 
       def deliver(email) do
@@ -143,9 +143,6 @@ defmodule Bamboo.Mailer do
   @doc false
   def parse_opts(mailer, opts) do
     otp_app = Keyword.fetch!(opts, :otp_app)
-    config = Application.get_env(otp_app, mailer)
-    adapter = Keyword.fetch!(config, :adapter)
-
-    %{adapter: adapter, config: config}
+    Application.get_env(otp_app, mailer) |> Enum.into(%{})
   end
 end

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -107,16 +107,16 @@ defmodule Bamboo.Mailer do
   end
 
   defp validate_and_normalize(email) do
-    email |> validate_recipients |> normalize_addresses
+    email |> validate |> normalize_addresses
   end
 
-  defp validate_recipients(email) do
-    if email.to == nil && email.cc == nil && email.bcc == nil do
-      raise Bamboo.NilRecipientsError, email
-    else
-      email
-    end
+  defp validate(%{from: nil}) do
+    raise Bamboo.EmptyFromAddressError, nil
   end
+  defp validate(%{to: nil, cc: nil, bcc: nil} = email) do
+    raise Bamboo.NilRecipientsError, email
+  end
+  defp validate(email), do: email
 
   @doc """
   Wraps to, cc and bcc addresses in a list and normalizes email addresses.
@@ -130,10 +130,6 @@ defmodule Bamboo.Mailer do
       cc: normalize(List.wrap(email.cc), :cc),
       bcc: normalize(List.wrap(email.bcc), :bcc)
     }
-  end
-
-  defp normalize(nil, :from) do
-    raise Bamboo.EmptyFromAddressError, nil
   end
 
   defp normalize(record, type) do

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -125,14 +125,14 @@ defmodule Bamboo.Mailer do
   """
   def normalize_addresses(email) do
     %{email |
-      from: normalize(email.from, :from),
-      to: normalize(List.wrap(email.to), :to),
-      cc: normalize(List.wrap(email.cc), :cc),
-      bcc: normalize(List.wrap(email.bcc), :bcc)
+      from: format(email.from, :from),
+      to: format(List.wrap(email.to), :to),
+      cc: format(List.wrap(email.cc), :cc),
+      bcc: format(List.wrap(email.bcc), :bcc)
     }
   end
 
-  defp normalize(record, type) do
+  defp format(record, type) do
     Formatter.format_email_address(record, %{type: type})
   end
 

--- a/lib/bamboo/strategies/deliver_immediately_strategy.ex
+++ b/lib/bamboo/strategies/deliver_immediately_strategy.ex
@@ -1,0 +1,13 @@
+defmodule Bamboo.DeliverImmediatelyStrategy do
+  @moduledoc """
+  Strategy that sends the email immediately. Useful for testing.
+
+  This strategy is used and required by the Bamboo.LocalAdapter and Bamboo.TestAdapter.
+  """
+
+  @behaviour Bamboo.DeliverLaterStrategy
+
+  def deliver_later(adapter, email, config) do
+    adapter.deliver(email, config)
+  end
+end

--- a/lib/bamboo/strategies/deliver_later_strategy_behaviour.ex
+++ b/lib/bamboo/strategies/deliver_later_strategy_behaviour.ex
@@ -1,0 +1,33 @@
+defmodule Bamboo.DeliverLaterStrategy do
+  @moduledoc """
+  Behaviour when creating strategies for delivering emails with deliver_later
+
+  Use this behaviour to create strategies for delivering later. You could make a
+  strategy using a GenServer, a backgrund job library or whatever else you
+  decide. Bamboo ships with two strategies:
+  [Bamboo.TaskSupervisorStrategy](Bamboo.TaskSupervisorStrategy.html) and
+  [Bamboo.DeliverImmediatelyStrategy](Bamboo.DeliverImmediatelyStrategy)
+
+  ## Example of setting custom strategies
+
+      config :my_app, MyApp.Mailer,
+        adapter: Bamboo.MandrillAdapter, # or whatever adapter you want
+        deliver_later_strategy: MyCustomStrategy
+
+  ## Example of delivery using Task.async
+
+      defmodule Bamboo.MyCustomStrategy do
+        @behaviour Bamboo.DeliverLaterStrategy
+
+        # This is a strategy for delivering later using Task.async
+        def deliver_later(adapter, email, config) do
+          Task.async fn ->
+            # Always call deliver on the adapter so that the email is delivered.
+            adapter.deliver(email, config)
+          end
+        end
+      end
+  """
+
+  @callback deliver_later(atom, %Bamboo.Email{}, map) :: any
+end

--- a/lib/bamboo/strategies/task_supervisor_strategy.ex
+++ b/lib/bamboo/strategies/task_supervisor_strategy.ex
@@ -1,0 +1,48 @@
+defmodule Bamboo.TaskSupervisorStrategy do
+  @behaviour Bamboo.DeliverLaterStrategy
+  @supervisor_name Bamboo.TaskSupervior
+
+  @moduledoc """
+  Default strategy. Sends an email in the background using Task.Supervisor
+
+  This is the default strategy because it is the simplest to get started with.
+  This strategy uses a Task.Supervisor to monitor the delivery. Deliveries that
+  fail will raise, but will not be retried.
+
+  To use this strategy, the Bamboo.TaskSupervior must be added to your
+  supervisor. See the docs for `child_spec` or check out the README.
+  """
+
+  @doc false
+  def deliver_later(adapter, email, config) do
+    Task.Supervisor.start_child @supervisor_name, fn ->
+      adapter.deliver(email, config)
+    end
+  end
+
+  @doc """
+  Child spec for use in your supervisor
+
+  ## Example
+
+      # Usually in lib/my_app_name/my_app_name.ex
+      def start(_type, _args) do
+        import Supervisor.Spec
+
+        children = [
+          # Add the supervisor that handles deliver_later calls
+          Bamboo.TaskSupervisorStrategy.child_spec
+        ]
+
+        # This part is usually already there.
+        opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+        Supervisor.start_link(children, opts)
+      end
+  """
+  def child_spec do
+    Supervisor.Spec.supervisor(
+      Task.Supervisor,
+      [[name: @supervisor_name]]
+    )
+  end
+end

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -27,13 +27,14 @@ defmodule Bamboo.MailerTest do
     :ok
   end
 
-  test "deliver/1 calls the adapter with the email and config" do
+  test "deliver/1 calls the adapter with the email and config as a map" do
     email = new_email(to: "foo@bar.com")
 
     returned_email = FooMailer.deliver(email)
 
     assert returned_email == Bamboo.Mailer.normalize_addresses(email)
-    assert_received {:deliver, %Bamboo.Email{}, @mailer_config}
+    assert_received {:deliver, %Bamboo.Email{}, config}
+    assert config == Enum.into(@mailer_config, %{})
   end
 
   test "deliver/1 with no from address" do
@@ -78,7 +79,7 @@ defmodule Bamboo.MailerTest do
     FooMailer.deliver_later(email)
 
     assert_receive {:deliver_later, delivered_email, config}
-    assert config == @mailer_config
+    assert config == Enum.into(@mailer_config, %{})
     assert delivered_email == Bamboo.Mailer.normalize_addresses(email)
   end
 

--- a/test/lib/bamboo/strategies/deliver_immediately_strategy_test.exs
+++ b/test/lib/bamboo/strategies/deliver_immediately_strategy_test.exs
@@ -1,0 +1,19 @@
+defmodule Bamboo.DeliverImmediatelyStrategyTest do
+  use ExUnit.Case
+
+  defmodule FakeAdapter do
+    def deliver(_email, _config), do: send self(), :delivered
+  end
+
+  @mailer_config %{}
+
+  test "deliver_later delivers right away" do
+    Bamboo.DeliverImmediatelyStrategy.deliver_later(
+      FakeAdapter,
+      Bamboo.Email.new_email,
+      @mailer_config
+    )
+
+    assert_receive :delivered
+  end
+end

--- a/test/lib/bamboo/strategies/task_supervisor_strategy_test.exs
+++ b/test/lib/bamboo/strategies/task_supervisor_strategy_test.exs
@@ -1,0 +1,32 @@
+defmodule Bamboo.TaskSupervisorStrategyTest do
+  use ExUnit.Case
+
+  defmodule FakeAdapter do
+    def deliver(_email, _config) do
+      send :task_supervisor_strategy_test, :delivered
+    end
+  end
+
+  @mailer_config %{}
+
+  test "deliver_later delivers the email" do
+    Process.register(self, :task_supervisor_strategy_test)
+
+    Bamboo.TaskSupervisorStrategy.deliver_later(
+      FakeAdapter,
+      Bamboo.Email.new_email,
+      @mailer_config
+    )
+
+    assert_receive :delivered
+  end
+
+  test "child_spec" do
+    spec = Bamboo.TaskSupervisorStrategy.child_spec
+
+    assert spec == Supervisor.Spec.supervisor(
+      Task.Supervisor,
+      [[name: Bamboo.TaskSupervior]]
+    )
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,9 @@
 ExUnit.start()
+
+Supervisor.start_child(
+  Bamboo.Supervisor,
+  Bamboo.TaskSupervisorStrategy.child_spec
+)
+
 Application.ensure_all_started(:phoenix)
 Application.ensure_all_started(:cowboy)


### PR DESCRIPTION
Closes #59 

@sorentwo @stevedomin You two were both interested in this I believe. What I did was move the deliver_later from the adapters to "deliver_later_strategies". So now you could create whatever strategy you want for deliver emails in the background. I think this simplifies adapters, and makes it easier to customize how you want to do background delivery. This also changes the default deliver_later strategy from using `Task.async` to using a `Task.Supervisor`.

LMK if you have any thoughts on this. @sorentwo With this new format you wouldn't need to create a new adapter, instead you would create a `GenServerStrategy` that you configure with `deliver_later_strategy: GenServerStrategy`.