### PR TITLE
Allow any strategy in local adapter

### DIFF
--- a/lib/bamboo/adapters/local_adapter.ex
+++ b/lib/bamboo/adapters/local_adapter.ex
@@ -28,22 +28,5 @@ defmodule Bamboo.LocalAdapter do
     SentEmail.push(email)
   end
 
-  def handle_config(config) do
-    case config[:deliver_later_strategy] do
-      nil ->
-        Map.put(config, :deliver_later_strategy, Bamboo.DeliverImmediatelyStrategy)
-      Bamboo.DeliverImmediatelyStrategy ->
-        config
-      _ ->
-        raise ArgumentError, """
-        Bamboo.LocalAdapter requires that the deliver_later_strategy is
-        Bamboo.DeliverImmediatelyStrategy
-
-        Instead it got: #{inspect config[:deliver_later_strategy]}
-
-        Please remove the deliver_later_strategy from your config options, or
-        set it to Bamboo.DeliverImmediatelyStrategy.
-        """
-    end
-  end
+  def handle_config(config), do: config
 end

--- a/test/lib/bamboo/local_adapter_test.exs
+++ b/test/lib/bamboo/local_adapter_test.exs
@@ -18,16 +18,4 @@ defmodule Bamboo.LocalAdapterTest do
 
     assert SentEmail.all == [email]
   end
-
-  test "handle_config makes sure that the DeliverImmediatelyStrategy is used" do
-    new_config = LocalAdapter.handle_config(%{})
-    assert new_config.deliver_later_strategy == Bamboo.DeliverImmediatelyStrategy
-
-    new_config = LocalAdapter.handle_config(%{deliver_later_strategy: nil})
-    assert new_config.deliver_later_strategy == Bamboo.DeliverImmediatelyStrategy
-
-    assert_raise ArgumentError, ~r/deliver_later_strategy/, fn ->
-      LocalAdapter.handle_config(%{deliver_later_strategy: FooStrategy})
-    end
-  end
 end


### PR DESCRIPTION
From discussion in https://github.com/paulcsmith/bamboo/pull/71/files#r53177410, we want to allow any strategy in the local adapter.

Closes https://github.com/paulcsmith/bamboo/issues/79