### PR TITLE
Only send deliver_later emails when there are recipients

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -87,7 +87,13 @@ defmodule Bamboo.Mailer do
   def deliver_later(adapter, email, config) do
     email = email |> validate_and_normalize
 
-    config.deliver_later_strategy.deliver_later(adapter, email, config)
+    if email.to == [] && email.cc == [] && email.bcc == [] do
+      debug_unsent(email)
+    else
+      debug_sent(email, adapter)
+      config.deliver_later_strategy.deliver_later(adapter, email, config)
+    end
+    email
   end
 
   defp debug_sent(email, adapter) do

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -81,30 +81,30 @@ defmodule Bamboo.MailerTest do
 
   test "deliver/1 with empty lists for recipients does not deliver email" do
     new_email(to: [], cc: [], bcc: []) |> FooMailer.deliver
-    refute_received {:deliver, _, @mailer_config}
+    refute_received {:deliver, _, _}
 
     new_email(to: [], cc: nil, bcc: nil) |> FooMailer.deliver
-    refute_received {:deliver, _, @mailer_config}
+    refute_received {:deliver, _, _}
 
     new_email(to: nil, cc: [], bcc: nil) |> FooMailer.deliver
-    refute_received {:deliver, _, @mailer_config}
+    refute_received {:deliver, _, _}
 
     new_email(to: nil, cc: nil, bcc: []) |> FooMailer.deliver
-    refute_received {:deliver, _, @mailer_config}
+    refute_received {:deliver, _, _}
   end
 
   test "deliver_later/1 with empty lists for recipients does not deliver email" do
     new_email(to: [], cc: [], bcc: []) |> FooMailer.deliver_later
-    refute_received {:deliver, _, @mailer_config}
+    refute_received {:deliver, _, _}
 
     new_email(to: [], cc: nil, bcc: nil) |> FooMailer.deliver_later
-    refute_received {:deliver, _, @mailer_config}
+    refute_received {:deliver, _, _}
 
     new_email(to: nil, cc: [], bcc: nil) |> FooMailer.deliver_later
-    refute_received {:deliver, _, @mailer_config}
+    refute_received {:deliver, _, _}
 
     new_email(to: nil, cc: nil, bcc: []) |> FooMailer.deliver_later
-    refute_received {:deliver, _, @mailer_config}
+    refute_received {:deliver, _, _}
   end
 
   test "deliver_later/1 calls deliver on the adapter" do


### PR DESCRIPTION
There was a bug in the test which has now been fixed along with the bug
fix in the mailer.