### PR TITLE
[RFC] Reorganise codebase to be more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Bamboo breaks email creation and email sending in to two separate modules.
 ```elixir
 # In your config/config.exs file
 config :my_app, MyApp.Mailer,
-  adapter: Bamboo.MandrillAdapter,
+  adapter: Bamboo.Adapters.Mandrill,
   api_key: "my_api_key"
 
 # Somewhere in your application
@@ -61,7 +61,7 @@ end
 defmodule MyApp.Emails do
   # Adds a `render` function for rending emails with a Phoenix view
   use Bamboo.Phoenix, view: MyApp.EmailView
-  import Bamboo.MandrillEmails
+  import Bamboo.Adapters.Mandrill
 
   def welcome_email do
     base_email
@@ -116,13 +116,13 @@ localhost:4000/delivered_emails
 
 ## Testing
 
-You can use the `Bamboo.TestAdapter` to make testing your emails a piece of cake.
+You can use the `Bamboo.Adapters.Test` to make testing your emails a piece of cake.
 See documentation for `Bamboo.Test` for more examples.
 
 ```elixir
-# Use the Bamboo.TestAdapter in your config/test.exs file
+# Use the Bamboo.Adapters.Test in your config/test.exs file
 config :my_app, MyApp.Mailer,
-  adapter: Bamboo.TestAdapter
+  adapter: Bamboo.Adapters.Test
 
 # Unit testing requires no special functions
 defmodule MyApp.EmailsTest do
@@ -183,7 +183,7 @@ To use the latest from master.
 
     children = [
       # Add the supervisor that handles deliver_later calls
-      Bamboo.TaskSupervisorStrategy.child_spec
+      Bamboo.Strategies.TaskSupervisor.child_spec
     ]
 
     # This part is usually already there.

--- a/lib/bamboo/adapter.ex
+++ b/lib/bamboo/adapter.ex
@@ -8,7 +8,7 @@ defmodule Bamboo.Adapter do
 
   ## Example
 
-      defmodule Bamboo.CustomAdapter do
+      defmodule Bamboo.Adapters.Custom do
         @behaviour Bamboo.Adapter
 
         def deliver(email, config) do

--- a/lib/bamboo/adapters/local.ex
+++ b/lib/bamboo/adapters/local.ex
@@ -1,4 +1,4 @@
-defmodule Bamboo.LocalAdapter do
+defmodule Bamboo.Adapters.Local do
   @moduledoc """
   Stores emails locally. Can be queried to see sent emails.
 
@@ -11,7 +11,7 @@ defmodule Bamboo.LocalAdapter do
 
       # In config/config.exs, or config/dev.exs, etc.
       config :my_app, MyApp.Mailer,
-        adapter: Bamboo.LocalAdapter
+        adapter: Bamboo.Adapters.Local
 
       # Define a Mailer. Maybe in lib/my_app/mailer.ex
       defmodule MyApp.Mailer do

--- a/lib/bamboo/adapters/mandrill.ex
+++ b/lib/bamboo/adapters/mandrill.ex
@@ -1,16 +1,18 @@
-defmodule Bamboo.MandrillAdapter do
+defmodule Bamboo.Adapters.Mandrill do
   @moduledoc """
   Sends email using Mandrill's JSON API.
 
   Use this adapter to send emails through Mandrill's API. Requires that an API
-  key is set in the config. See [Bamboo.MandrillEmail](Bamboo.MandrillEmail.html)
-  for extra functions that can be used by the MandrillAdapter (tagging, merge vars, etc.)
+  key is set in the config.
+
+  See [Bamboo.Adapters.Mandrill.Email](Bamboo.Adapters.Mandrill.Email.html) for extra
+  functions that can be used by the Mandrill adapter (tagging, merge vars, etc.).
 
   ## Example config
 
       # In config/config.exs, or config/prod.exs, etc.
       config :my_app, MyApp.Mailer,
-        adapter: Bamboo.MandrillAdapter,
+        adapter: Bamboo.Adapters.Mandrill,
         api_key: "my_api_key"
 
       # Define a Mailer. Maybe in lib/my_app/mailer.ex

--- a/lib/bamboo/adapters/mandrill/email.ex
+++ b/lib/bamboo/adapters/mandrill/email.ex
@@ -1,4 +1,4 @@
-defmodule Bamboo.MandrillEmail do
+defmodule Bamboo.Adapters.Mandrill.Email do
   @moduledoc """
   Functions for using features specific to Mandrill.
   """
@@ -9,7 +9,7 @@ defmodule Bamboo.MandrillEmail do
   Put extra message parameters that are used by Mandrill
 
   Parameters set with this function are sent to Mandrill when used along with
-  the Bamboo.MandrillAdapter. You can set things like `important`, `merge_vars`,
+  the Bamboo.Adapters.Mandrill. You can set things like `important`, `merge_vars`,
   and whatever else you need that the Mandrill API supports.
 
   ## Example

--- a/lib/bamboo/adapters/test.ex
+++ b/lib/bamboo/adapters/test.ex
@@ -1,4 +1,4 @@
-defmodule Bamboo.TestAdapter do
+defmodule Bamboo.Adapters.Test do
   @moduledoc """
   Used for testing email delivery
 
@@ -9,7 +9,7 @@ defmodule Bamboo.TestAdapter do
 
       # Typically done in config/test.exs
       config :my_app, MyApp.Mailer,
-        adapter: Bamboo.TestAdapter
+        adapter: Bamboo.Adapters.Test
 
       # Define a Mailer. Maybe in lib/my_app/mailer.ex
       defmodule MyApp.Mailer do
@@ -27,18 +27,18 @@ defmodule Bamboo.TestAdapter do
   def handle_config(config) do
     case config[:deliver_later_strategy] do
       nil ->
-        Map.put(config, :deliver_later_strategy, Bamboo.ImmediateDeliveryStrategy)
-      Bamboo.ImmediateDeliveryStrategy ->
+        Map.put(config, :deliver_later_strategy, Bamboo.Strategies.ImmediateDelivery)
+      Bamboo.Strategies.ImmediateDelivery ->
         config
       _ ->
         raise ArgumentError, """
-        Bamboo.TestAdapter requires that the deliver_later_strategy is
-        Bamboo.ImmediateDeliveryStrategy
+        Bamboo.Adapters.Test requires that the deliver_later_strategy is
+        Bamboo.Strategies.ImmediateDelivery
 
         Instead it got: #{inspect config[:deliver_later_strategy]}
 
         Please remove the deliver_later_strategy from your config options, or
-        set it to Bamboo.ImmediateDeliveryStrategy.
+        set it to Bamboo.Strategies.ImmediateDelivery.
         """
     end
   end

--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -3,17 +3,17 @@ defmodule Bamboo.Mailer do
   Sets up mailers that make it easy to configure and swap adapters.
 
   Adds deliver/1 and deliver_later/1 functions to the mailer module it is used by.
-  Bamboo ships with [Bamboo.MandrillAdapter](Bamboo.MandrillAdapter.html),
-  [Bamboo.LocalAdapter](Bamboo.LocalAdapter) and
-  [Bamboo.TestAdapter](Bamboo.TestAdapter.html).
+  Bamboo ships with [Bamboo.Adapters.Mandrill](Bamboo.Adapters.Mandrill.html),
+  [Bamboo.Adapters.Local](Bamboo.Adapters.Local) and
+  [Bamboo.Adapters.Test](Bamboo.Adapters.Test.html).
 
   ## Example
 
       # In your config/config.exs file
       # Other adapters that come with Bamboo are
-      # Bamboo.LocalAdapter and Bamboo.TestAdapter
+      # Bamboo.Adapters.Local and Bamboo.Adapters.Test
       config :my_app, MyApp.Mailer,
-        adapter: Bamboo.MandrillAdapter,
+        adapter: Bamboo.Adapters.Mandrill,
         api_key: "my_api_key"
 
       # Somewhere in your application. Maybe lib/my_app/mailer.ex
@@ -148,6 +148,6 @@ defmodule Bamboo.Mailer do
     config = Application.get_env(otp_app, mailer) |> Enum.into(%{})
 
     config.adapter.handle_config(config)
-    |> Map.put_new(:deliver_later_strategy, Bamboo.TaskSupervisorStrategy)
+    |> Map.put_new(:deliver_later_strategy, Bamboo.Strategies.TaskSupervisor)
   end
 end

--- a/lib/bamboo/sent_email.ex
+++ b/lib/bamboo/sent_email.ex
@@ -1,8 +1,9 @@
 defmodule Bamboo.SentEmail do
   @moduledoc """
-  Used for storing and retrieving sent emails when used with Bamboo.LocalAdapter
+  Used for storing and retrieving sent emails when used with
+  Bamboo.Adapters.Local
 
-  When emails are sent with the Bamboo.LocalAdapter, they are stored in
+  When emails are sent with the Bamboo.Adapters.Local, they are stored in
   Bamboo.SentEmail. Use the following function to store and retrieve the emails.
   Remember to start the Bamboo app by adding it to the app list in mix.exs or
   starting it with Application.ensure_all_started(:bamboo)

--- a/lib/bamboo/strategies/immediate_delivery.ex
+++ b/lib/bamboo/strategies/immediate_delivery.ex
@@ -1,11 +1,12 @@
-defmodule Bamboo.ImmediateDeliveryStrategy do
+defmodule Bamboo.Strategies.ImmediateDelivery do
   @moduledoc """
   Strategy that sends the email immediately. Useful for testing.
 
-  This strategy is used and required by the Bamboo.LocalAdapter and Bamboo.TestAdapter.
+  This strategy is used and required by the Bamboo.Adapters.Local and
+  Bamboo.Adapters.Test
   """
 
-  @behaviour Bamboo.DeliverLaterStrategy
+  @behaviour Bamboo.Strategy
 
   def deliver_later(adapter, email, config) do
     adapter.deliver(email, config)

--- a/lib/bamboo/strategies/task_supervisor.ex
+++ b/lib/bamboo/strategies/task_supervisor.ex
@@ -1,5 +1,5 @@
-defmodule Bamboo.TaskSupervisorStrategy do
-  @behaviour Bamboo.DeliverLaterStrategy
+defmodule Bamboo.Strategies.TaskSupervisor do
+  @behaviour Bamboo.Strategy
   @supervisor_name Bamboo.TaskSupervior
 
   @moduledoc """
@@ -31,7 +31,7 @@ defmodule Bamboo.TaskSupervisorStrategy do
 
         children = [
           # Add the supervisor that handles deliver_later calls
-          Bamboo.TaskSupervisorStrategy.child_spec
+          Bamboo.Strategies.TaskSupervisor.child_spec
         ]
 
         # This part is usually already there.

--- a/lib/bamboo/strategy.ex
+++ b/lib/bamboo/strategy.ex
@@ -1,23 +1,23 @@
-defmodule Bamboo.DeliverLaterStrategy do
+defmodule Bamboo.Strategy do
   @moduledoc """
   Behaviour when creating strategies for delivering emails with deliver_later
 
   Use this behaviour to create strategies for delivering later. You could make a
   strategy using a GenServer, a backgrund job library or whatever else you
   decide. Bamboo ships with two strategies:
-  [Bamboo.TaskSupervisorStrategy](Bamboo.TaskSupervisorStrategy.html) and
-  [Bamboo.ImmediateDeliveryStrategy](Bamboo.ImmediateDeliveryStrategy)
+  [Bamboo.Strategies.TaskSupervisor](Bamboo.Strategies.TaskSupervisor.html) and
+  [Bamboo.Strategies.ImmediateDelivery](Bamboo.Strategies.ImmediateDelivery)
 
   ## Example of setting custom strategies
 
       config :my_app, MyApp.Mailer,
-        adapter: Bamboo.MandrillAdapter, # or whatever adapter you want
+        adapter: Bamboo.Adapters.Mandrill, # or whatever adapter you want
         deliver_later_strategy: MyCustomStrategy
 
   ## Example of delivery using Task.async
 
       defmodule Bamboo.MyCustomStrategy do
-        @behaviour Bamboo.DeliverLaterStrategy
+        @behaviour Bamboo.Strategy
 
         # This is a strategy for delivering later using Task.async
         def deliver_later(adapter, email, config) do

--- a/lib/bamboo/test.ex
+++ b/lib/bamboo/test.ex
@@ -2,7 +2,7 @@ defmodule Bamboo.Test do
   @moduledoc """
   Helpers for testing email delivery
 
-  Use these helpers with Bamboo.TestAdapter to test email delivery. Typically
+  Use these helpers with Bamboo.Adapters.Test to test email delivery. Typically
   you'll want to **unit test emails and then in integration tests use
   helpers from this module** to test whether that email was delivered.
 
@@ -72,7 +72,7 @@ defmodule Bamboo.Test do
   @doc """
   Checks whether an email was delivered.
 
-  Must be used with the Bamboo.TestAdapter or this will never pass. If a
+  Must be used with the Bamboo.Adapters.Test or this will never pass. If a
   Bamboo.Email struct is passed in, it will check that all fields are matching.
 
   You can also pass a keyword list and it will check just the fields you pass in.

--- a/test/lib/bamboo/adapters/local_test.exs
+++ b/test/lib/bamboo/adapters/local_test.exs
@@ -1,7 +1,7 @@
-defmodule Bamboo.LocalAdapterTest do
+defmodule Bamboo.Adapters.LocalTest do
   use ExUnit.Case
   alias Bamboo.SentEmail
-  alias Bamboo.LocalAdapter
+  alias Bamboo.Adapters.Local
   import Bamboo.Email, only: [new_email: 0, new_email: 1]
 
   @config %{}
@@ -14,7 +14,7 @@ defmodule Bamboo.LocalAdapterTest do
   test "sent emails has emails that were delivered synchronously" do
     email = new_email(subject: "This is my email")
 
-    email |> LocalAdapter.deliver(@config)
+    email |> Local.deliver(@config)
 
     assert SentEmail.all == [email]
   end

--- a/test/lib/bamboo/adapters/mandrill/email_test.exs
+++ b/test/lib/bamboo/adapters/mandrill/email_test.exs
@@ -1,19 +1,19 @@
-defmodule Bamboo.MandrillEmailTest do
+defmodule Bamboo.Adapters.Mandrill.EmailTest do
   use ExUnit.Case
   import Bamboo.Email
-  alias Bamboo.MandrillEmail
+  alias Bamboo.Adapters.Mandrill.Email
 
   test "put_param/3 puts a map in private.message_params" do
-    email = new_email |> MandrillEmail.put_param("track_links", true)
+    email = new_email |> Email.put_param("track_links", true)
 
     assert email.private.message_params == %{"track_links" => true}
   end
 
   test "adds tags to mandrill emails" do
-    email = new_email |> MandrillEmail.tag("welcome-email")
+    email = new_email |> Email.tag("welcome-email")
     assert email.private.message_params == %{"tags" => ["welcome-email"]}
 
-    email = new_email |> MandrillEmail.tag(["welcome-email", "awesome"])
+    email = new_email |> Email.tag(["welcome-email", "awesome"])
     assert email.private.message_params == %{"tags" => ["welcome-email", "awesome"]}
   end
 end

--- a/test/lib/bamboo/adapters/test_test.exs
+++ b/test/lib/bamboo/adapters/test_test.exs
@@ -1,37 +1,37 @@
-defmodule Bamboo.TestAdapterTest do
+defmodule Bamboo.Adapters.TestTest do
   use ExUnit.Case
   use Bamboo.Test
   import Bamboo.Email, only: [new_email: 0, new_email: 1]
-  alias Bamboo.TestAdapter
+  alias Bamboo.Adapters.Test
 
   @config %{}
 
   Application.put_env(
     :bamboo,
     __MODULE__.TestMailer,
-    adapter: Bamboo.TestAdapter
+    adapter: Bamboo.Adapters.Test
   )
 
   defmodule TestMailer do
     use Bamboo.Mailer, otp_app: :bamboo
   end
 
-  test "handle_config makes sure that the ImmediateDeliveryStrategy is used" do
-    new_config = TestAdapter.handle_config(%{})
-    assert new_config.deliver_later_strategy == Bamboo.ImmediateDeliveryStrategy
+  test "handle_config makes sure that the ImmediateDelivery strategy is used" do
+    new_config = Test.handle_config(%{})
+    assert new_config.deliver_later_strategy == Bamboo.Strategies.ImmediateDelivery
 
-    new_config = TestAdapter.handle_config(%{deliver_later_strategy: nil})
-    assert new_config.deliver_later_strategy == Bamboo.ImmediateDeliveryStrategy
+    new_config = Test.handle_config(%{deliver_later_strategy: nil})
+    assert new_config.deliver_later_strategy == Bamboo.Strategies.ImmediateDelivery
 
     assert_raise ArgumentError, ~r/deliver_later_strategy/, fn ->
-      TestAdapter.handle_config(%{deliver_later_strategy: FooStrategy})
+      Test.handle_config(%{deliver_later_strategy: FooStrategy})
     end
   end
 
   test "deliver/2 sends a message to the process" do
     email = new_email()
 
-    email |> TestAdapter.deliver(@config)
+    email |> Test.deliver(@config)
 
     assert_received {:delivered_email, ^email}
   end

--- a/test/lib/bamboo/mailer_test.exs
+++ b/test/lib/bamboo/mailer_test.exs
@@ -56,7 +56,7 @@ defmodule Bamboo.MailerTest do
     FooMailer.deliver(email)
 
     assert_received {:deliver, _email, config}
-    assert config.deliver_later_strategy == Bamboo.TaskSupervisorStrategy
+    assert config.deliver_later_strategy == Bamboo.Strategies.TaskSupervisor
   end
 
   test "deliver/1 calls the adapter with the email and config as a map" do
@@ -67,7 +67,7 @@ defmodule Bamboo.MailerTest do
     assert returned_email == Bamboo.Mailer.normalize_addresses(email)
     assert_received {:deliver, %Bamboo.Email{}, config}
     config_with_default_strategy = Enum.into(@mailer_config, %{})
-      |> Map.put(:deliver_later_strategy, Bamboo.TaskSupervisorStrategy)
+      |> Map.put(:deliver_later_strategy, Bamboo.Strategies.TaskSupervisor)
     assert config == config_with_default_strategy
   end
 

--- a/test/lib/bamboo/strategies/immediate_delivery_test.exs
+++ b/test/lib/bamboo/strategies/immediate_delivery_test.exs
@@ -1,4 +1,4 @@
-defmodule Bamboo.ImmediateDeliveryStrategyTest do
+defmodule Bamboo.ImmediateDeliveryTest do
   use ExUnit.Case
 
   defmodule FakeAdapter do
@@ -8,7 +8,7 @@ defmodule Bamboo.ImmediateDeliveryStrategyTest do
   @mailer_config %{}
 
   test "deliver_later delivers right away" do
-    Bamboo.ImmediateDeliveryStrategy.deliver_later(
+    Bamboo.Strategies.ImmediateDelivery.deliver_later(
       FakeAdapter,
       Bamboo.Email.new_email,
       @mailer_config

--- a/test/lib/bamboo/strategies/task_supervisor_test.exs
+++ b/test/lib/bamboo/strategies/task_supervisor_test.exs
@@ -1,18 +1,18 @@
-defmodule Bamboo.TaskSupervisorStrategyTest do
+defmodule Bamboo.Strategies.TaskSupervisorTest do
   use ExUnit.Case
 
   defmodule FakeAdapter do
     def deliver(_email, _config) do
-      send :task_supervisor_strategy_test, :delivered
+      send :task_supervisor_test, :delivered
     end
   end
 
   @mailer_config %{}
 
   test "deliver_later delivers the email" do
-    Process.register(self, :task_supervisor_strategy_test)
+    Process.register(self, :task_supervisor_test)
 
-    Bamboo.TaskSupervisorStrategy.deliver_later(
+    Bamboo.Strategies.TaskSupervisor.deliver_later(
       FakeAdapter,
       Bamboo.Email.new_email,
       @mailer_config
@@ -22,7 +22,7 @@ defmodule Bamboo.TaskSupervisorStrategyTest do
   end
 
   test "child_spec" do
-    spec = Bamboo.TaskSupervisorStrategy.child_spec
+    spec = Bamboo.Strategies.TaskSupervisor.child_spec
 
     assert spec == Supervisor.Spec.supervisor(
       Task.Supervisor,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,7 +2,7 @@ ExUnit.start()
 
 Supervisor.start_child(
   Bamboo.Supervisor,
-  Bamboo.TaskSupervisorStrategy.child_spec
+  Bamboo.Strategies.TaskSupervisor.child_spec
 )
 
 Application.ensure_all_started(:phoenix)


### PR DESCRIPTION
While working on a new adapter I found that the code organisation wasn't
necessarily consistent with what can be found in the Elixir codebase,
Ecto or Phoenix.

I opened the PR to kick start the discussion but there are still a couple of things I'm not happy with:
* The naming of the "Test" adapters leads to some weirdness: test file is named `test_test.exs` and the module name is TestTest. The purpose of the Local and Test adapter seems very similar so  I'm wondering if there isn't something we could do there. I've started playing with some ideas here.
* `Bamboo.SentEmail` is only useful for  `Bamboo.Adapters.Local` so the module should probably be moved closer to the adapter (e.g. `lib/adapters/local/sent_email.ex`)
* I'm also want to nest the strategies under `Bamboo.Strategies`. I'm actually thinking that maybe we should just get rid of the whole deliver/deliver_later and just have deliver but with a behaviour dependent on the strategy used. What do you think?

This is obviously a breaking change but since Bamboo hasn't reached 1.0 yet, now is the time :)

@paulcsmith would love to have your feedback on that